### PR TITLE
Delete failed CallRecording file

### DIFF
--- a/src/com/android/services/callrecorder/CallRecorderService.java
+++ b/src/com/android/services/callrecorder/CallRecorderService.java
@@ -169,12 +169,18 @@ public class CallRecorderService extends Service {
             return true;
         } catch (IOException e) {
             Log.w(TAG, "Could not start recording for file " + outputPath, e);
+            Log.w(TAG, "Deleting failed recording " + outputPath);
+            file.delete();
         } catch (IllegalStateException e) {
             Log.w(TAG, "Could not start recording for file " + outputPath, e);
+            Log.w(TAG, "Deleting failed recording " + outputPath);
+            file.delete();
         } catch (RuntimeException e) {
             // only catch exceptions thrown by the MediaRecorder JNI code
             if (e.getMessage().indexOf("start failed") >= 0) {
                 Log.w(TAG, "Could not start recording for file " + outputPath, e);
+                Log.w(TAG, "Deleting failed recording " + outputPath);
+                file.delete();
             } else {
                 throw e;
             }


### PR DESCRIPTION
Created CallRecording file isn't deleted when CallRecording fails. This
results in an empty file. Try deleting this file, if an error occurs.

Change-Id: Ia3a75c3575a6efe7aea12cbf6c110f20601519e7
Signed-off-by: Arvind Mukund <armu30@gmail.com>