### PR TITLE
Fix crash in call log.

### DIFF
--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -78,6 +78,13 @@
         <item name="android:colorPrimaryDark">@color/dialer_theme_color_dark</item>
         <item name="dialpad_key_button_touch_tint">@color/dialer_dialpad_touch_tint</item>
         <item name="android:colorControlActivated">@color/dialer_theme_color</item>
+
+        <!-- Trick the support libraries into thinking this is an AppCompat theme. We don't
+             need the full thing, but we want to use CoordinatorLayout in our view hierarchy,
+             which checks for being used with an AppCompat theme on creation. -->
+        <item name="colorAccent">@color/dialtacts_theme_color</item>
+        <item name="colorPrimary">@color/dialer_theme_color</item>
+        <item name="colorPrimaryDark">@color/dialer_theme_color_dark</item>
     </style>
 
     <!-- Action bar overflow menu icon. -->


### PR DESCRIPTION
The latest CoordinatorLayout code checks for being used with an
AppCompat theme on creation. As we neither need nor want to go the full
AppCompat route and the CoordinatorLayout works fine without the
AppCompat theme for what we're using it for, pretend our theme is
AppCompat based just to make the check happy.

Change-Id: I5fa321790fe539ceee652da8416297e009e1c495