### PR TITLE
Fix crash in Settings when clicking on Phone Number Lookup

### DIFF
--- a/src/com/android/dialer/settings/LookupSettingsFragment.java
+++ b/src/com/android/dialer/settings/LookupSettingsFragment.java
@@ -154,6 +154,11 @@ public class LookupSettingsFragment extends PreferenceFragment
     }
 
     private void restoreLookupProvider(ListPreference pref, String key) {
+        if (pref.getEntries().length < 1) {
+            pref.setEnabled(false);
+            return;
+        }
+
         final ContentResolver cr = getActivity().getContentResolver();
         String provider = CMSettings.System.getString(cr, key);
         if (provider == null) {


### PR DESCRIPTION
List preferences in Phone Number Lookup can have zero
entries. Disable those preferences.

Caused by: java.lang.ArrayIndexOutOfBoundsException: length=0; index=0
at android.preference.ListPreference.setValueIndex(ListPreference.java:199)
at com.android.dialer.settings.LookupSettingsFragment.restoreLookupProvider(LookupSettingsFragment.java:160)
at com.android.dialer.settings.LookupSettingsFragment.restoreLookupProviders(LookupSettingsFragment.java:151)
at com.android.dialer.settings.LookupSettingsFragment.onResume(LookupSettingsFragment.java:83)

Change-Id: I21eda536eaecb569716927fd47db3408a191a91c
Issue-Id: CYNGNOS-2547