### PR TITLE
Fix NPE when checking default Dialer

### DIFF
--- a/src/com/android/dialer/calllog/CallLogFragment.java
+++ b/src/com/android/dialer/calllog/CallLogFragment.java
@@ -509,6 +509,11 @@ public class CallLogFragment extends Fragment implements CallLogQueryHandler.Lis
 
     /** Requests updates to the data to be shown. */
     private void refreshData() {
+        if (!isAdded() || getActivity() == null) {
+            // Fragment is not attached to the activity nothing to do
+            return;
+        }
+
         // Prevent unnecessary refresh.
         if (mRefreshDataRequired) {
             // Mark all entries in the contact info cache as out of date, so they will be looked up
@@ -550,8 +555,13 @@ public class CallLogFragment extends Fragment implements CallLogQueryHandler.Lis
             if (!onEntry) {
                 mCallLogQueryHandler.markMissedCallsAsRead();
             }
-            CallLogNotificationsHelper.removeMissedCallNotifications(getActivity());
-            CallLogNotificationsHelper.updateVoicemailNotifications(getActivity());
+
+            Activity activity = getActivity();
+            if (activity == null) {
+                return;
+            }
+            CallLogNotificationsHelper.removeMissedCallNotifications(activity);
+            CallLogNotificationsHelper.updateVoicemailNotifications(activity);
         }
     }
 


### PR DESCRIPTION
* CallLogFragment may attempt to refresh it's data even when it's
* detached from the activity. Add an activity null check before
* attempting use getActivity for Context.

Ticket: CD-673

Change-Id: I8d003d99c3dfa25cbb9edc9df2dab9fb25523573