### PR TITLE
Increment nudge only after shown intent returns

### DIFF
--- a/src/com/android/dialer/discovery/DiscoverySignalReceiver.java
+++ b/src/com/android/dialer/discovery/DiscoverySignalReceiver.java
@@ -57,13 +57,7 @@ public class DiscoverySignalReceiver extends BroadcastReceiver {
         switch (action) {
             case Intent.ACTION_NEW_OUTGOING_CALL:
                 String phoneNumber = intent.getStringExtra(Intent.EXTRA_PHONE_NUMBER);
-                SharedPreferences preferences = context
-                        .getSharedPreferences(DialtactsActivity.SHARED_PREFS_NAME,
-                                Context.MODE_PRIVATE);
-                int currentCount = preferences.getInt(CallMethodUtils.PREF_INTERNATIONAL_CALLS, 0);
                 if (isMaybeInternationalNumber(context, phoneNumber)) {
-                    preferences.edit().putInt(CallMethodUtils.PREF_INTERNATIONAL_CALLS,
-                            ++currentCount).apply();
                     startServiceForInternationalCallMade(context);
                 }
                 break;
@@ -89,6 +83,10 @@ public class DiscoverySignalReceiver extends BroadcastReceiver {
                 editor.putLong(countKey, count);
                 editor.putLong(timeKey, System.currentTimeMillis());
                 editor.apply();
+
+                // The nudge was shown, so we want to increment the count because this is a real
+                // event.
+                DiscoveryEventHandler.incrementCount(nudgeKey, context);
 
                 recordDiscoveryCount(nudgeComponent, nudgeKey,
                         InCallMetricsHelper.Parameters.COUNT);

--- a/src/com/android/dialer/discovery/WifiCallStatusNudgeListener.java
+++ b/src/com/android/dialer/discovery/WifiCallStatusNudgeListener.java
@@ -140,20 +140,11 @@ public class WifiCallStatusNudgeListener {
     private static void callOnWifiSuccess() {
         if (DEBUG) Log.v(TAG, "call was made with wifi connected the whole time");
 
-        SharedPreferences preferences = mContext
-                .getSharedPreferences(DialtactsActivity.SHARED_PREFS_NAME, Context.MODE_PRIVATE);
-
-        int currentCount;
         // If the network is roaming and we are on wifi,
         // then we want to show a potential roaming nudge instead of a wifi nudge.
         if (mTelephonyManager.isNetworkRoaming()) {
-            currentCount = preferences.getInt(CallMethodUtils.PREF_ROAMING_CALLS, 0);
-            preferences.edit().putInt(CallMethodUtils.PREF_ROAMING_CALLS, ++currentCount).apply();
             DiscoverySignalReceiver.startServiceForConnectivityChanged(mContext);
         } else {
-            currentCount = preferences.getInt(CallMethodUtils.PREF_WIFI_CALL, 0);
-            preferences.edit().putInt(CallMethodUtils.PREF_WIFI_CALL, ++currentCount).apply();
-
             new DiscoveryEventHandler(mContext).getNudgeProvidersWithKey(
                     NudgeKey.NOTIFICATION_WIFI_CALL);
         }


### PR DESCRIPTION
Previously there was a chance that a nudge would be sent to
discovery but then not shown.

Ticket: CD-681
Change-Id: I8671a83b23ed77b2ae1fabcfcdf4a01ec5eae108