### PR TITLE
Makes private the ambient connection check, to stop log spam.

### DIFF
--- a/src/com/android/dialer/deeplink/DeepLinkIntegrationManager.java
+++ b/src/com/android/dialer/deeplink/DeepLinkIntegrationManager.java
@@ -164,7 +164,7 @@ public class DeepLinkIntegrationManager {
      * @param ctx   context to query against
      * @return      true if ambient is available, false otherwise.
      */
-    public boolean ambientIsAvailable(Context ctx) {
+    private boolean ambientIsAvailable(Context ctx) {
         return CyanogenAmbientUtil.isCyanogenAmbientAvailable(ctx) == CyanogenAmbientUtil.SUCCESS;
     }
 


### PR DESCRIPTION
External classes were using this method in places they shouldn't
causing a lot of log spam.  This should help stop that behavior.

NOTES-150

Change-Id: Id29793f3ca2fbe1be02a36b0f0be6a8594afd246