### PR TITLE
[3/4] Add cancel callback for BlockContactDialog

### DIFF
--- a/src/com/android/dialer/CallDetailActivity.java
+++ b/src/com/android/dialer/CallDetailActivity.java
@@ -407,6 +407,11 @@ public class CallDetailActivity extends Activity
     }
 
     @Override
+    public void onBlockCancelled() {
+        // Do nothing
+    }
+
+    @Override
     public void onBlockSelected(boolean notifyLookupProvider) {
         mBlockContactHelper.blockContactAsync(notifyLookupProvider);
     }

--- a/src/com/android/dialer/calllog/CallLogFragment.java
+++ b/src/com/android/dialer/calllog/CallLogFragment.java
@@ -594,6 +594,11 @@ public class CallLogFragment extends Fragment implements CallLogQueryHandler.Lis
     }
 
     @Override
+    public void onBlockCancelled() {
+        // Do nothing
+    }
+
+    @Override
     public void onBlockSelected(boolean notifyLookupProvider) {
         mBlockContactPresenter.onBlockSelected(notifyLookupProvider);
     }

--- a/src/com/android/dialer/callstats/CallStatsDetailActivity.java
+++ b/src/com/android/dialer/callstats/CallStatsDetailActivity.java
@@ -189,6 +189,11 @@ public class CallStatsDetailActivity extends Activity implements
     }
 
     @Override
+    public void onBlockCancelled() {
+        // Do nothing
+    }
+
+    @Override
     public void onBlockSelected(boolean notifyLookupProvider) {
         mBlockContactHelper.blockContactAsync(notifyLookupProvider);
     }


### PR DESCRIPTION
Some ui elements need to refresh themselves when the dialog
is cancelled. This allows them to do that.

Change-Id: I61d5b08300820843499ba0ef1b28ff732efcaa08
Ticket: CYNGNOS-3111