### PR TITLE
dialer: search: Don't attempt to get resources on a detached fragment

### DIFF
--- a/src/com/android/dialer/list/SearchFragment.java
+++ b/src/com/android/dialer/list/SearchFragment.java
@@ -556,7 +556,7 @@ public class SearchFragment extends PhoneNumberPickerFragment
 
     public void setupEmptyView() {
         DialtactsActivity dialActivity = (DialtactsActivity) mActivity;
-        if (mEmptyView != null && dialActivity != null) {
+        if (mEmptyView != null && dialActivity != null && isAdded()) {
             ContactEntryListAdapter adapter = getAdapter();
             Resources r = getResources();
             mEmptyView.setWidth(dialActivity.getDialpadWidth());


### PR DESCRIPTION
During the activity lifecycle, the user might have used the search
fragment but then place the call via other means and in that case the
search fragment will be detached. It does, however, still try to set
itself up and in the process attempts to obtain context-bound items such
as Resources and the Dialer app crashes.

Change-Id: Id3b9f376e282f4f8a04960eb3c4a5eac0d2ea9ad
Ticket: FEIJAO-1173