### PR TITLE
Dialer: Fix proximity on wake handling

### DIFF
--- a/InCallUI/src/com/android/incallui/ProximitySensor.java
+++ b/InCallUI/src/com/android/incallui/ProximitySensor.java
@@ -241,8 +241,6 @@ public class ProximitySensor implements AccelerometerListener.OrientationListene
                     || CallAudioState.ROUTE_SPEAKER == audioMode
                     || CallAudioState.ROUTE_BLUETOOTH == audioMode
                     || mIsHardKeyboardOpen);
-            screenOnImmediately |= CMSettings.System.getInt(mContext.getContentResolver(),
-                    CMSettings.System.PROXIMITY_ON_WAKE, 1) == 0;
 
             // We do not keep the screen off when the user is outside in-call screen and we are
             // horizontal, but we do not force it on when we become horizontal until the
@@ -268,7 +266,11 @@ public class ProximitySensor implements AccelerometerListener.OrientationListene
                     .add("aud", CallAudioState.audioRouteToString(audioMode))
                     .toString());
 
-            if ((mIsPhoneOffhook || mHasIncomingCall) && !screenOnImmediately) {
+            final boolean proximityOnWake = CMSettings.System.getInt(mContext.getContentResolver(),
+                    CMSettings.System.PROXIMITY_ON_WAKE, 1) == 1;
+
+            if ((mIsPhoneOffhook || (mHasIncomingCall && proximityOnWake))
+                    && !screenOnImmediately) {
                 Log.d(this, "Turning on proximity sensor");
                 // Phone is idle.  We don't want any special proximity sensor
                 // behavior in this case.


### PR DESCRIPTION
*) http://review.cyanogenmod.org/#/c/167122/ introduced an issue
   where the screen would never turn off during a call if the system
   proximity on wake setting was turned off.

*) Fix this by making sure the proximity_on_wake setting is only
   used when we have an incoming call.

Change-Id: I49f8759112c4f9bfe41325dd3329eb2d1902231f